### PR TITLE
feat: expose mcp server options

### DIFF
--- a/bridge/config.go
+++ b/bridge/config.go
@@ -8,14 +8,17 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	"github.com/mark3labs/mcp-go/server"
 )
 
 // Config holds configuration for the MCP command
 type Config struct {
-	AppName    string
-	AppVersion string
-	LogFile    string
-	LogLevel   string
+	AppName       string
+	AppVersion    string
+	LogFile       string
+	LogLevel      string
+	ServerOptions []server.ServerOption
 }
 
 // newSlogger makes a new slog.logger that writes to file. Don't give the user
@@ -87,4 +90,13 @@ func parseLogLevel(level string) slog.Level {
 	}
 
 	return slogLevel
+}
+
+// GetServerOptions returns the configured server options.
+// Returns an empty slice if ServerOptions is nil or empty.
+func (c *Config) GetServerOptions() []server.ServerOption {
+	if c.ServerOptions == nil {
+		return []server.ServerOption{}
+	}
+	return c.ServerOptions
 }

--- a/bridge/manager.go
+++ b/bridge/manager.go
@@ -70,6 +70,7 @@ func New(factory CommandFactory, config *Config) (*Manager, error) {
 		server: server.NewMCPServer(
 			config.AppName,
 			config.AppVersion,
+			config.GetServerOptions()...,
 		),
 	}
 


### PR DESCRIPTION
## What does this PR do?

This PR exposes MCP `server.ServerOption` through the bridge config.

Alternatively, we could add a getter for `server.MCPServer` in `bridge.Manager` so that the `MCPServer` is fully accessible to callers that want to customize it beyond the automatic tool registration.

I did this so that I can add custom prompts, but I can imagine also configuring resources, middleware, etc. and I assume that's out of scope for this library

## Related Issues
N/A

## Checklist

- [ ] ~Tests added or updated~ - IMO given we're just passing these along and there's no business logic around it I'm not sure it's valuable to test this here. LMK if you feel there would be value out of testing this. 
- [x] Ready for review
