### PR TITLE
feat(tools): add cmd.example to description

### DIFF
--- a/tools/command.go
+++ b/tools/command.go
@@ -84,6 +84,10 @@ func descFromCmd(cmd *cobra.Command) string {
 		desc = cmd.Short
 	}
 
+	if cmd.Example != "" {
+		desc += "\nExamples:\n" + cmd.Example
+	}
+
 	return desc
 }
 

--- a/tools/command_test.go
+++ b/tools/command_test.go
@@ -256,6 +256,7 @@ func TestCommandDescriptions(t *testing.T) {
 		name     string
 		short    string
 		long     string
+		example  string
 		expected string
 	}{
 		{
@@ -270,15 +271,23 @@ func TestCommandDescriptions(t *testing.T) {
 			long:     "",
 			expected: "Only short description",
 		},
+		{
+			name:     "adds example to description",
+			short:    "Only short description",
+			long:     "",
+			example:  "and example",
+			expected: "Only short description\nExamples:\nand example",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{
-				Use:   "test",
-				Short: tt.short,
-				Long:  tt.long,
-				Run:   func(_ *cobra.Command, _ []string) {},
+				Use:     "test",
+				Short:   tt.short,
+				Long:    tt.long,
+				Example: tt.example,
+				Run:     func(_ *cobra.Command, _ []string) {},
 			}
 
 			generator := NewGenerator()


### PR DESCRIPTION
## What does this PR do?

When cmd.Example is populated, provide it to the LLM as part of the command description. 

## Related Issues

Closes #6 
@tj-smith47

## Checklist

- [x] Tests added or updated
- [x] Ready for review
