### PR TITLE
Updated controller flag parsing to support slices of arguments

### DIFF
--- a/tools/controller_test.go
+++ b/tools/controller_test.go
@@ -115,6 +115,22 @@ func TestBuildFlagArgs(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "string slice flag",
+			flagMap: map[string]any{
+				"flag":  []any{"value1", "value2"},
+				"flag2": "json",
+			},
+			expected: []string{"--flag", "value1", "--flag", "value2", "--flag2", "json"},
+		},
+		{
+			name: "bool slice flag",
+			flagMap: map[string]any{
+				"flag":  []any{true, false, true},
+				"flag2": true,
+			},
+			expected: []string{"--flag", "--flag", "--flag2"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


## What does this PR do?

Before this change was created when a flag that contained a slice of arguments was processed it would show up in the command like --flag "[value1 value2]". The command would see this as a single value and process it incorrectly. The same would occur with a slice of one value for example, --flag "[value1]". After this change the flag is split into multiple flags, --flag "value1" --flag "value2". I figured this would be safer than trying to escape commas and concat the values around a comma.

## Related Issues

I didn't open an issue. Let me know if I need to.

## Checklist

- [x] Tests added or updated
- [x] Ready for review
