### PR TITLE
feat: add `stream` cmd for http server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ go.work.sum
 # build output
 bin/
 output/
+*.pem
 
 # log files
 *.log

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ tools.WithHandler(func(ctx context.Context, request mcp.CallToolRequest, data []
 ```
 mcp
 ├── start            # Start MCP server on stdio
+├── stream           # Start MCP server in HTTP streaming mode
 ├── tools            # Export available MCP tools as JSON
 ├── claude
 │   ├── enable       # Enable Helm MCP in Claude Desktop

--- a/config.go
+++ b/config.go
@@ -44,11 +44,10 @@ type Config struct {
 	SloggerOptions *slog.HandlerOptions
 
 	// ServerOptions provides additional options for the underlying MCP server.
-	// Optional: These are passed directly to the mark3labs/mcp-go server.
-	// The bridge always adds server.WithRecovery() to handle panics gracefully.
-	//
-	// Consult the mark3labs/mcp-go documentation for available server options.
 	ServerOptions []server.ServerOption
+
+	// StreamOptions provides options for the HTTP stream transport.
+	StreamOptions []server.StreamableHTTPOption
 }
 
 func (c *Config) bridgeConfig(cmd *cobra.Command) *bridge.Config {
@@ -62,6 +61,7 @@ func (c *Config) bridgeConfig(cmd *cobra.Command) *bridge.Config {
 		GeneratorOptions: c.GeneratorOptions,
 		SloggerOptions:   c.SloggerOptions,
 		ServerOptions:    c.ServerOptions,
+		StreamOptions:    c.StreamOptions,
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -28,7 +28,8 @@
 //	}
 //
 // This adds the following subcommands to your CLI:
-//   - mcp start: Start the MCP server
+//   - mcp start: Start the MCP server on stdio
+//   - mcp stream: Start the MCP server in HTTP streaming mode
 //   - mcp tools: List available tools
 //   - mcp claude enable/disable/list: Manage Claude Desktop integration
 //   - mcp vscode enable/disable/list: Manage VSCode integration
@@ -39,10 +40,10 @@
 //
 //	config := &ophis.Config{
 //	    // Control which commands are exposed
-//	    Generator: tools.NewGenerator(
+//	    Generator: []tools.GeneratorOption{
 //	        tools.WithFilters(tools.Allow([]string{"get", "list"})),
 //	        tools.WithHandler(customHandler),
-//	    ),
+//	    },
 //
 //	    // Configure logging
 //	    SloggerOptions: &slog.HandlerOptions{

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,10 @@
 # Examples
 
-### External Examples
+## Internal Examples
+Build all examples with `make build`.
 
+### Make Example
+Shows how to expose make commands as MCP tools.
+
+## External Examples
 For visibility, external examples are listed in the [root README](../README.md#Examples).

--- a/internal/bridge/config.go
+++ b/internal/bridge/config.go
@@ -11,19 +11,6 @@ import (
 
 // Config holds configuration for creating an MCP server bridge from a Cobra CLI application.
 // It defines how the CLI commands are exposed as MCP tools and how the server behaves.
-//
-// Example usage:
-//
-//	config := &bridge.Config{
-//		RootCmd:    rootCmd,
-//		Generator: tools.NewGenerator(
-//			tools.WithFilters(tools.Allow([]string{"get", "list"})),
-//			tools.WithHandler(customHandler),
-//		),
-//		SloggerOptions: &slog.HandlerOptions{
-//			Level: slog.LevelDebug,
-//		},
-//	}
 type Config struct {
 	// RootCmd is the root Cobra command whose subcommands will be exposed as MCP tools.
 	// Required: This is the entry point for discovering available commands.
@@ -37,6 +24,9 @@ type Config struct {
 
 	// ServerOptions provides additional options for the underlying MCP server.
 	ServerOptions []server.ServerOption
+
+	// StreamOptions provides options for the HTTP stream transport.
+	StreamOptions []server.StreamableHTTPOption
 }
 
 // Tools returns the list of MCP tools generated from the root command.

--- a/internal/bridge/serve.go
+++ b/internal/bridge/serve.go
@@ -1,0 +1,36 @@
+package bridge
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// ServeIO starts the MCP server using stdio for communication.
+func (c *Config) ServeIO() error {
+	m := c.newManager()
+	return server.ServeStdio(m.server)
+}
+
+// ServeHTTP starts the MCP server with an HTTP transport on the specified address.
+func (c *Config) ServeHTTP(addr string) error {
+	m := c.newManager()
+	server := server.NewStreamableHTTPServer(m.server, c.StreamOptions...)
+
+	// shutdown server gracefully on interrupt signal
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, os.Interrupt)
+		<-sigCh
+		slog.Info("shutting down MCP HTTP server")
+		if err := server.Shutdown(context.Background()); err != nil {
+			slog.Error("error shutting down MCP HTTP server", "error", err)
+		}
+	}()
+
+	slog.Info("starting MCP HTTP server", "address", addr)
+	return server.Start(addr)
+}

--- a/root.go
+++ b/root.go
@@ -17,6 +17,6 @@ func Command(config *Config) *cobra.Command {
 	}
 
 	// Add subcommands
-	cmd.AddCommand(startCommand(config), toolCommand(config), claude.Command(), vscode.Command())
+	cmd.AddCommand(startCommand(config), streamCommand(config), toolCommand(config), claude.Command(), vscode.Command())
 	return cmd
 }

--- a/start.go
+++ b/start.go
@@ -3,7 +3,6 @@ package ophis
 import (
 	"log/slog"
 
-	"github.com/njayp/ophis/internal/bridge"
 	"github.com/njayp/ophis/internal/cfgmgr"
 	"github.com/spf13/cobra"
 )
@@ -36,7 +35,7 @@ func startCommand(config *Config) *cobra.Command {
 			}
 
 			// Create and start the bridge
-			return bridge.Run(config.bridgeConfig(cmd))
+			return config.bridgeConfig(cmd).ServeIO()
 		},
 	}
 

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,72 @@
+package ophis
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+)
+
+// StreamCommandFlags holds configuration flags for the stream command.
+type StreamCommandFlags struct {
+	LogLevel string
+	Address  string
+	CertFile string
+	KeyFile  string
+}
+
+// streamCommand creates a Cobra command for starting the MCP server in HTTP streaming mode.
+func streamCommand(config *Config) *cobra.Command {
+	streamFlags := &StreamCommandFlags{}
+	cmd := &cobra.Command{
+		Use:   "stream",
+		Short: "Start the MCP server in HTTP streaming mode",
+		Long: `Start MCP server in HTTP streaming mode to expose CLI commands to AI assistants.
+This mode allows connections over HTTP with server-sent events (SSE) for real-time streaming.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if config == nil {
+				config = &Config{}
+			}
+
+			if streamFlags.LogLevel != "" {
+				level := parseLogLevel(streamFlags.LogLevel)
+				// Ensure SloggerOptions is initialized
+				if config.SloggerOptions == nil {
+					config.SloggerOptions = &slog.HandlerOptions{}
+				}
+				// Set the log level based on the flag
+				config.SloggerOptions.Level = level
+			}
+
+			// Validate address
+			if streamFlags.Address == "" {
+				return fmt.Errorf("address is required for HTTP streaming mode")
+			}
+
+			switch {
+			case (streamFlags.CertFile == "") != (streamFlags.KeyFile == ""):
+				return fmt.Errorf("both cert-file and key-file must be provided to enable TLS")
+			case streamFlags.CertFile != "" && streamFlags.KeyFile != "":
+				slog.Info("TLS enabled for HTTP streaming server")
+				config.StreamOptions = append(config.StreamOptions,
+					server.WithTLSCert(streamFlags.CertFile, streamFlags.KeyFile),
+				)
+			default:
+				slog.Info("TLS not enabled; using plain HTTP for streaming server")
+			}
+
+			// Create and start the bridge in HTTP mode
+			return config.bridgeConfig(cmd).ServeHTTP(streamFlags.Address)
+		},
+	}
+
+	// Add flags
+	flags := cmd.Flags()
+	flags.StringVar(&streamFlags.LogLevel, "log-level", "", "Log level (debug, info, warn, error)")
+	flags.StringVarP(&streamFlags.Address, "address", "a", ":8080", "Address to listen on (e.g., :8080, localhost:3000)")
+	flags.StringVar(&streamFlags.CertFile, "cert-file", "", "Path to TLS certificate file (enables HTTPS)")
+	flags.StringVar(&streamFlags.KeyFile, "key-file", "", "Path to TLS key file (enables HTTPS)")
+
+	return cmd
+}


### PR DESCRIPTION
## What does this PR do?

- Adds http streaming server option
- Adds `stream` cmd to start http server

I'm not sure if this would be useful to anyone. Please let me know if you want this.

## Checklist

- [x] Tests added or updated
- [x] Docs added or updated