### PR TITLE
Serialize MCP-supplied object to string for JSON schema flags

### DIFF
--- a/config.go
+++ b/config.go
@@ -131,8 +131,11 @@ func (c *Config) registerToolsRecursive(cmd *cobra.Command) {
 		}
 
 		// create tool from cmd
-		tool := s.createToolFromCmd(cmd)
+		tool, metadata := s.createToolFromCmd(cmd)
 		slog.Debug("created tool", "tool_name", tool.Name, "selector_index", i)
+
+		// store flag metadata in registry for proper serialization
+		globalFlagRegistry.Register(tool.Name, metadata)
 
 		// register tool with server
 		mcp.AddTool(c.server, tool, s.execute)

--- a/flag_registry.go
+++ b/flag_registry.go
@@ -1,0 +1,44 @@
+package ophis
+
+// FlagMetadata tracks metadata about a flag for proper serialization
+type FlagMetadata struct {
+	// HasJSONSchema indicates if this flag uses a JSON schema annotation
+	// and should be marshaled as JSON instead of key-value pairs
+	HasJSONSchema bool
+}
+
+// FlagMetadataByFlagName contains metadata for all flags by flag name for a single tool
+type FlagMetadataByFlagName map[string]FlagMetadata
+
+// FlagRegistry stores Metadata about all tool flags
+// It is populated once during server initialization and then remains read-only
+type FlagRegistry struct {
+	// tools maps tool name -> flag name -> metadata
+	tools map[string]FlagMetadataByFlagName
+}
+
+// NewFlagRegistry creates a new empty flag registry
+func NewFlagRegistry() *FlagRegistry {
+	return &FlagRegistry{
+		tools: make(map[string]FlagMetadataByFlagName),
+	}
+}
+
+// Register stores flag metadata for a tool
+func (r *FlagRegistry) Register(toolName string, flags FlagMetadataByFlagName) {
+	r.tools[toolName] = flags
+}
+
+// HasJSONSchema checks if a specific flag has a JSON schema annotation
+// Returns false if tool or flag is not found
+func (r *FlagRegistry) HasJSONSchema(toolName string, flagName string) bool {
+	if flags, ok := r.tools[toolName]; ok {
+		if meta, ok := flags[flagName]; ok {
+			return meta.HasJSONSchema
+		}
+	}
+	return false
+}
+
+// globalFlagRegistry is populated during server initialization
+var globalFlagRegistry = NewFlagRegistry()

--- a/internal/bridge/flags/flags.go
+++ b/internal/bridge/flags/flags.go
@@ -26,6 +26,19 @@ func isFlagRequired(flag *pflag.Flag) bool {
 	return false
 }
 
+// HasJSONSchemaAnnotation checks if a flag has a JSON schema annotation
+// Returns true if the flag has a non-empty jsonschema annotation that was successfully parsed
+func HasJSONSchemaAnnotation(flag *pflag.Flag) bool {
+	if flag.Annotations == nil {
+		return false
+	}
+	schemaStrArray, ok := flag.Annotations["jsonschema"]
+	if !ok || len(schemaStrArray) == 0 {
+		return false
+	}
+	return true
+}
+
 // AddFlagToSchema adds a single flag to the schema properties.
 func AddFlagToSchema(schema *jsonschema.Schema, flag *pflag.Flag) {
 	flagSchema := &jsonschema.Schema{

--- a/selector_test.go
+++ b/selector_test.go
@@ -112,7 +112,7 @@ func TestCreateToolFromCmd(t *testing.T) {
 
 	t.Run("Default Selector", func(t *testing.T) {
 		// Create tool from command with a selector that accepts all flags
-		tool := Selector{}.createToolFromCmd(cmd)
+		tool, _ := Selector{}.createToolFromCmd(cmd)
 
 		// Verify tool properties
 		assert.Equal(t, "parent_test", tool.Name)
@@ -219,7 +219,7 @@ func TestCreateToolFromCmd(t *testing.T) {
 		}
 
 		// Create tool from command with the restricted selector
-		tool := selector.createToolFromCmd(cmd)
+		tool, _ := selector.createToolFromCmd(cmd)
 
 		// Verify tool properties
 		assert.Equal(t, "parent_test", tool.Name)


### PR DESCRIPTION
## What does this PR do?

When MCP supplies an object as a flag value into Ophis because that flag has a `jsonschema` annotation then Cobra needs that flag as a JSON string. This PR adds the missing part of the feature in #31, whereby Ophis converts the object into a JSON string.

## Related Issues

Fix #35 

## Checklist

- [x] Tests added or updated
- [x] Docs added or updated