### PR TITLE
Add tool annotations from command annotations

### DIFF
--- a/annotations.go
+++ b/annotations.go
@@ -1,0 +1,102 @@
+package ophis
+
+import (
+	"log/slog"
+	"strconv"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/cobra"
+)
+
+// Cobra command annotation keys for MCP tool annotations.
+// Set these in cmd.Annotations to populate mcp.ToolAnnotations on the generated tool.
+//
+// Boolean values are parsed with strconv.ParseBool (accepts "1", "t", "true", "0", "f", "false", etc.).
+//
+// Example:
+//
+//	cmd.Annotations = map[string]string{
+//	    ophis.AnnotationReadOnly: "true",
+//	    ophis.AnnotationTitle:    "List files",
+//	}
+const (
+	// AnnotationTitle sets the human-readable title for the tool.
+	AnnotationTitle = "title"
+
+	// AnnotationReadOnly hints that the tool does not modify its environment.
+	AnnotationReadOnly = "readOnlyHint"
+
+	// AnnotationDestructive hints that the tool may perform destructive updates.
+	// Only meaningful when ReadOnlyHint is false.
+	AnnotationDestructive = "destructiveHint"
+
+	// AnnotationIdempotent hints that calling the tool repeatedly with the same
+	// arguments has no additional effect. Only meaningful when ReadOnlyHint is false.
+	AnnotationIdempotent = "idempotentHint"
+
+	// AnnotationOpenWorld hints that the tool may interact with external entities
+	// outside its closed domain.
+	AnnotationOpenWorld = "openWorldHint"
+)
+
+// toolAnnotations reads MCP annotation keys from cmd.Annotations and
+// returns a populated *mcp.ToolAnnotations, or nil if no MCP annotations are found.
+func toolAnnotations(cmd *cobra.Command) *mcp.ToolAnnotations {
+	if len(cmd.Annotations) == 0 {
+		return nil
+	}
+
+	var annotations mcp.ToolAnnotations
+	found := false
+
+	if v, ok := cmd.Annotations[AnnotationTitle]; ok {
+		annotations.Title = v
+		found = true
+	}
+
+	if v, ok := cmd.Annotations[AnnotationReadOnly]; ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("invalid bool value for annotation, skipping", "key", AnnotationReadOnly, "value", v)
+		} else {
+			annotations.ReadOnlyHint = b
+			found = true
+		}
+	}
+
+	if v, ok := cmd.Annotations[AnnotationDestructive]; ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("invalid bool value for annotation, skipping", "key", AnnotationDestructive, "value", v)
+		} else {
+			annotations.DestructiveHint = &b
+			found = true
+		}
+	}
+
+	if v, ok := cmd.Annotations[AnnotationIdempotent]; ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("invalid bool value for annotation, skipping", "key", AnnotationIdempotent, "value", v)
+		} else {
+			annotations.IdempotentHint = b
+			found = true
+		}
+	}
+
+	if v, ok := cmd.Annotations[AnnotationOpenWorld]; ok {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			slog.Warn("invalid bool value for annotation, skipping", "key", AnnotationOpenWorld, "value", v)
+		} else {
+			annotations.OpenWorldHint = &b
+			found = true
+		}
+	}
+
+	if !found {
+		return nil
+	}
+
+	return &annotations
+}

--- a/annotations_test.go
+++ b/annotations_test.go
@@ -1,0 +1,211 @@
+package ophis
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestToolAnnotationsFromCmd(t *testing.T) {
+	t.Run("no annotations returns nil", func(t *testing.T) {
+		cmd := &cobra.Command{Use: "test"}
+		assert.Nil(t, toolAnnotations(cmd))
+	})
+
+	t.Run("non-MCP annotations returns nil", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{"custom": "value", "other": "data"},
+		}
+		assert.Nil(t, toolAnnotations(cmd))
+	})
+
+	t.Run("title", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationTitle: "My Tool"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.Equal(t, "My Tool", ann.Title)
+	})
+
+	t.Run("readOnlyHint true", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationReadOnly: "true"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.True(t, ann.ReadOnlyHint)
+	})
+
+	t.Run("readOnlyHint false", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationReadOnly: "false"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.False(t, ann.ReadOnlyHint)
+	})
+
+	t.Run("destructiveHint true", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationDestructive: "true"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.Equal(t, boolPtr(true), ann.DestructiveHint)
+	})
+
+	t.Run("destructiveHint false", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationDestructive: "false"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.Equal(t, boolPtr(false), ann.DestructiveHint)
+	})
+
+	t.Run("idempotentHint", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationIdempotent: "true"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.True(t, ann.IdempotentHint)
+	})
+
+	t.Run("openWorldHint true", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationOpenWorld: "true"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.Equal(t, boolPtr(true), ann.OpenWorldHint)
+	})
+
+	t.Run("openWorldHint false", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:         "test",
+			Annotations: map[string]string{AnnotationOpenWorld: "false"},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.Equal(t, boolPtr(false), ann.OpenWorldHint)
+	})
+
+	t.Run("all fields together", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use: "test",
+			Annotations: map[string]string{
+				AnnotationTitle:       "Delete Resource",
+				AnnotationReadOnly:    "false",
+				AnnotationDestructive: "true",
+				AnnotationIdempotent:  "true",
+				AnnotationOpenWorld:   "false",
+			},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann)
+		assert.Equal(t, "Delete Resource", ann.Title)
+		assert.False(t, ann.ReadOnlyHint)
+		assert.Equal(t, boolPtr(true), ann.DestructiveHint)
+		assert.True(t, ann.IdempotentHint)
+		assert.Equal(t, boolPtr(false), ann.OpenWorldHint)
+	})
+
+	t.Run("invalid bool value is skipped", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use: "test",
+			Annotations: map[string]string{
+				AnnotationReadOnly:    "notabool",
+				AnnotationDestructive: "invalid",
+				AnnotationIdempotent:  "nope",
+				AnnotationOpenWorld:   "bad",
+			},
+		}
+		ann := toolAnnotations(cmd)
+		assert.Nil(t, ann, "all invalid bools should result in nil annotations")
+	})
+
+	t.Run("mixed valid and invalid values", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use: "test",
+			Annotations: map[string]string{
+				AnnotationTitle:    "My Tool",
+				AnnotationReadOnly: "notabool",
+			},
+		}
+		ann := toolAnnotations(cmd)
+		require.NotNil(t, ann, "should still return annotations for valid fields")
+		assert.Equal(t, "My Tool", ann.Title)
+		assert.False(t, ann.ReadOnlyHint, "invalid readOnlyHint should remain zero value")
+	})
+
+	t.Run("strconv.ParseBool variants", func(t *testing.T) {
+		for _, v := range []string{"1", "t", "TRUE", "True"} {
+			cmd := &cobra.Command{
+				Use:         "test",
+				Annotations: map[string]string{AnnotationReadOnly: v},
+			}
+			ann := toolAnnotations(cmd)
+			require.NotNil(t, ann, "value %q should parse as true", v)
+			assert.True(t, ann.ReadOnlyHint, "value %q should parse as true", v)
+		}
+		for _, v := range []string{"0", "f", "FALSE", "False"} {
+			cmd := &cobra.Command{
+				Use:         "test",
+				Annotations: map[string]string{AnnotationDestructive: v},
+			}
+			ann := toolAnnotations(cmd)
+			require.NotNil(t, ann, "value %q should parse as false", v)
+			assert.Equal(t, boolPtr(false), ann.DestructiveHint, "value %q should parse as false", v)
+		}
+	})
+}
+
+func TestCreateToolFromCmd_Annotations(t *testing.T) {
+	t.Run("annotations propagated to tool", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:   "delete",
+			Short: "Delete a resource",
+			Run:   func(_ *cobra.Command, _ []string) {},
+			Annotations: map[string]string{
+				AnnotationTitle:       "Delete Resource",
+				AnnotationDestructive: "true",
+				AnnotationOpenWorld:   "false",
+			},
+		}
+		root := &cobra.Command{Use: "app"}
+		root.AddCommand(cmd)
+
+		tool := Selector{}.createToolFromCmd(cmd, "app")
+		require.NotNil(t, tool.Annotations)
+		assert.Equal(t, "Delete Resource", tool.Annotations.Title)
+		assert.Equal(t, boolPtr(true), tool.Annotations.DestructiveHint)
+		assert.Equal(t, boolPtr(false), tool.Annotations.OpenWorldHint)
+	})
+
+	t.Run("no annotations results in nil", func(t *testing.T) {
+		cmd := &cobra.Command{
+			Use:   "list",
+			Short: "List resources",
+			Run:   func(_ *cobra.Command, _ []string) {},
+		}
+		root := &cobra.Command{Use: "app"}
+		root.AddCommand(cmd)
+
+		tool := Selector{}.createToolFromCmd(cmd, "app")
+		assert.Nil(t, tool.Annotations)
+	})
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -133,6 +133,46 @@ Middleware: func(ctx context.Context, req *mcp.CallToolRequest, in ophis.ToolInp
 }
 ```
 
+## Tool Annotations
+
+Set MCP [tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations) on Cobra commands using `cmd.Annotations`. These hints help AI clients make informed decisions about tool invocation.
+
+### Available Annotation Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `ophis.AnnotationTitle` (`"title"`) | string | Human-readable title for the tool |
+| `ophis.AnnotationReadOnly` (`"readOnlyHint"`) | bool | Tool does not modify its environment |
+| `ophis.AnnotationDestructive` (`"destructiveHint"`) | bool | Tool may perform destructive updates |
+| `ophis.AnnotationIdempotent` (`"idempotentHint"`) | bool | Repeated calls have no additional effect |
+| `ophis.AnnotationOpenWorld` (`"openWorldHint"`) | bool | Tool may interact with external entities |
+
+Boolean values are parsed with `strconv.ParseBool` (`"true"`, `"1"`, `"t"`, `"false"`, `"0"`, `"f"`, etc.). Invalid values are skipped with a warning.
+
+### Example
+
+```go
+listCmd := &cobra.Command{
+    Use:   "list",
+    Short: "List all resources",
+    Annotations: map[string]string{
+        ophis.AnnotationTitle:    "List Resources",
+        ophis.AnnotationReadOnly: "true",
+    },
+}
+
+deleteCmd := &cobra.Command{
+    Use:   "delete [id]",
+    Short: "Delete a resource",
+    Annotations: map[string]string{
+        ophis.AnnotationTitle:       "Delete Resource",
+        ophis.AnnotationDestructive: "true",
+        ophis.AnnotationIdempotent:  "true",
+        ophis.AnnotationOpenWorld:   "false",
+    },
+}
+```
+
 ## Logging
 
 ```go

--- a/selector.go
+++ b/selector.go
@@ -128,6 +128,7 @@ func (s Selector) createToolFromCmd(cmd *cobra.Command, toolNamePrefix string) *
 		Description:  toolDescription(cmd),
 		InputSchema:  schema,
 		OutputSchema: outputSchema.Copy(),
+		Annotations:  toolAnnotations(cmd),
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

This allows you to specify tool annotations as cobra command annotations.

## Related Issues

Closes #123

## Checklist

- [X] Tests added or updated
- [X] Docs added or updated