### PR TITLE
Support overriding the MCP server name in config

### DIFF
--- a/config.go
+++ b/config.go
@@ -54,6 +54,14 @@ type Config struct {
 	// If nil, no default environment variables are added (current behavior).
 	DefaultEnv map[string]string
 
+	// ServerName is the default name used for the MCP server entry that
+	// `enable` writes into (and `disable` removes from) an editor's config
+	// file (Claude Desktop, VSCode, Cursor). It is overridden by the
+	// `--server-name` flag when provided.
+	//
+	// If empty, the server name is derived from the executable's file name.
+	ServerName string
+
 	// ToolNamePrefix replaces the root command name in tool names.
 	// This is useful for shortening tool names to comply with API limits (e.g., Claude's 64 char limit).
 	// For example, if root command is "omnistrate-ctl" and ToolNamePrefix is "omctl",

--- a/docs/config.md
+++ b/docs/config.md
@@ -8,6 +8,7 @@ Selectors control which commands and flags become MCP tools. Ophis evaluates sel
 
 - If `Config.Selectors` is nil/empty, all commands and flags are exposed
 - If `Config.DefaultEnv` is nil, no default environment variables are added to editor configs
+- If `Config.ServerName` is empty, the MCP server entry name is derived from the executable's file name
 - If `CmdSelector` is nil, the selector matches all commands
 - If `LocalFlagSelector` or `InheritedFlagSelector` is nil, all flags are included
 
@@ -60,6 +61,35 @@ User-provided `--env` values always take precedence over `DefaultEnv`:
 # Overrides DefaultEnv PATH with user value, keeps other DefaultEnv vars
 ./my-cli mcp claude enable --env PATH=/custom/path
 ```
+
+## ServerName
+
+`enable` writes an MCP server entry into each editor's config file (Claude Desktop, VSCode, Cursor). By default, the entry name is derived from the executable's file name. `ServerName` sets a default name instead:
+
+```go
+config := &ophis.Config{
+    ServerName: "my-cli",
+}
+```
+
+The `--server-name` flag on `enable` always takes precedence over `ServerName`:
+
+```bash
+# Uses ServerName from Config
+./my-cli mcp claude enable
+
+# Overrides ServerName with the flag value
+./my-cli mcp claude enable --server-name custom-name
+```
+
+`disable` uses the same precedence, so an entry created by `enable` is removed by `disable` without needing to repeat the name:
+
+```bash
+# Removes the entry named by ServerName from Config
+./my-cli mcp claude disable
+```
+
+When both `ServerName` and `--server-name` are empty, the name falls back to the executable's file name.
 
 ## Examples
 

--- a/internal/cfgmgr/cmd/claude/disable.go
+++ b/internal/cfgmgr/cmd/claude/disable.go
@@ -1,21 +1,20 @@
 package claude
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/njayp/ophis/internal/cfgmgr/manager"
 	"github.com/spf13/cobra"
 )
 
 type disableFlags struct {
-	configPath string
-	serverName string
+	defaultServerName string
+	configPath        string
+	serverName        string
 }
 
 // disableCommand creates a Cobra command for removing an MCP server from Claude Desktop.
-func disableCommand() *cobra.Command {
-	f := &disableFlags{}
+// serverName is the default MCP server entry name; the --server-name flag overrides it.
+func disableCommand(serverName string) *cobra.Command {
+	f := &disableFlags{defaultServerName: serverName}
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Remove server from Claude config",
@@ -28,18 +27,15 @@ func disableCommand() *cobra.Command {
 	// Add flags
 	flags := cmd.Flags()
 	flags.StringVar(&f.configPath, "config-path", "", "Path to Claude config file")
-	flags.StringVar(&f.serverName, "server-name", "", "Name of the MCP server to remove (default: derived from executable name)")
+	flags.StringVar(&f.serverName, "server-name", "", manager.ServerNameRemoveUsage(serverName))
 	return cmd
 }
 
 func (f *disableFlags) run() error {
-	if f.serverName == "" {
-		executablePath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("failed to determine executable path: %w", err)
-		}
-
-		f.serverName = manager.DeriveServerName(executablePath)
+	// Resolve the server name (flag → configured default → executable name).
+	serverName, err := manager.ResolveServerName(f.serverName, f.defaultServerName)
+	if err != nil {
+		return err
 	}
 
 	m, err := manager.NewClaudeManager(f.configPath)
@@ -47,5 +43,5 @@ func (f *disableFlags) run() error {
 		return err
 	}
 
-	return m.DisableServer(f.serverName)
+	return m.DisableServer(serverName)
 }

--- a/internal/cfgmgr/cmd/claude/enable.go
+++ b/internal/cfgmgr/cmd/claude/enable.go
@@ -10,18 +10,20 @@ import (
 )
 
 type enableFlags struct {
-	commandName string
-	defaultEnv  map[string]string
-	configPath  string
-	logLevel    string
-	serverName  string
-	env         map[string]string
+	commandName       string
+	defaultServerName string
+	defaultEnv        map[string]string
+	configPath        string
+	logLevel          string
+	serverName        string
+	env               map[string]string
 }
 
 // enableCommand creates a Cobra command for adding an MCP server to Claude Desktop.
+// serverName is the default MCP server entry name; the --server-name flag overrides it.
 // defaultEnv is merged into the server env; user-provided --env values take precedence.
-func enableCommand(commandName string, defaultEnv map[string]string) *cobra.Command {
-	f := &enableFlags{commandName: commandName, defaultEnv: defaultEnv}
+func enableCommand(commandName, serverName string, defaultEnv map[string]string) *cobra.Command {
+	f := &enableFlags{commandName: commandName, defaultServerName: serverName, defaultEnv: defaultEnv}
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Add server to Claude config",
@@ -35,7 +37,7 @@ func enableCommand(commandName string, defaultEnv map[string]string) *cobra.Comm
 	flags := cmd.Flags()
 	flags.StringVar(&f.logLevel, "log-level", "", "Log level (debug, info, warn, error)")
 	flags.StringVar(&f.configPath, "config-path", "", "Path to Claude config file")
-	flags.StringVar(&f.serverName, "server-name", "", "Name for the MCP server (default: derived from executable name)")
+	flags.StringVar(&f.serverName, "server-name", "", manager.ServerNameUsage(serverName))
 	flags.StringToStringVarP(&f.env, "env", "e", nil, "Environment variables (e.g., --env KEY1=value1 --env KEY2=value2)")
 	return cmd
 }
@@ -76,8 +78,10 @@ func (f *enableFlags) run(cmd *cobra.Command) error {
 		server.Env = env
 	}
 
-	if f.serverName == "" {
-		f.serverName = manager.DeriveServerName(executablePath)
+	// Resolve the server name (flag → configured default → executable name).
+	f.serverName, err = manager.ResolveServerName(f.serverName, f.defaultServerName)
+	if err != nil {
+		return err
 	}
 
 	m, err := manager.NewClaudeManager(f.configPath)

--- a/internal/cfgmgr/cmd/claude/root.go
+++ b/internal/cfgmgr/cmd/claude/root.go
@@ -7,8 +7,10 @@ import (
 // Command creates a new Cobra command for managing Claude Desktop MCP servers.
 // commandName is the name of the ophis root command (e.g. "mcp" or "agent"),
 // used by enable to build the correct command path for editor config files.
+// serverName is the default MCP server entry name for enable; the --server-name
+// flag overrides it, and an empty value falls back to the executable name.
 // defaultEnv is merged into the server env on enable; user --env values take precedence.
-func Command(commandName string, defaultEnv map[string]string) *cobra.Command {
+func Command(commandName, serverName string, defaultEnv map[string]string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "claude",
 		Short: "Manage Claude Desktop MCP servers",
@@ -16,6 +18,6 @@ func Command(commandName string, defaultEnv map[string]string) *cobra.Command {
 	}
 
 	// Add subcommands
-	cmd.AddCommand(enableCommand(commandName, defaultEnv), disableCommand(), listCommand())
+	cmd.AddCommand(enableCommand(commandName, serverName, defaultEnv), disableCommand(serverName), listCommand())
 	return cmd
 }

--- a/internal/cfgmgr/cmd/cursor/disable.go
+++ b/internal/cfgmgr/cmd/cursor/disable.go
@@ -1,22 +1,21 @@
 package cursor
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/njayp/ophis/internal/cfgmgr/manager"
 	"github.com/spf13/cobra"
 )
 
 type disableFlags struct {
-	configPath string
-	serverName string
-	workspace  bool
+	defaultServerName string
+	configPath        string
+	serverName        string
+	workspace         bool
 }
 
 // disableCommand creates a Cobra command for removing an MCP server from Cursor.
-func disableCommand() *cobra.Command {
-	f := &disableFlags{}
+// serverName is the default MCP server entry name; the --server-name flag overrides it.
+func disableCommand(serverName string) *cobra.Command {
+	f := &disableFlags{defaultServerName: serverName}
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Remove server from Cursor config",
@@ -29,20 +28,17 @@ func disableCommand() *cobra.Command {
 	// Add flags
 	flags := cmd.Flags()
 	flags.StringVar(&f.configPath, "config-path", "", "Path to Cursor config file")
-	flags.StringVar(&f.serverName, "server-name", "", "Name of the MCP server to remove (default: derived from executable name)")
+	flags.StringVar(&f.serverName, "server-name", "", manager.ServerNameRemoveUsage(serverName))
 	flags.BoolVar(&f.workspace, "workspace", false, "Remove from workspace settings (.cursor/mcp.json) instead of user settings")
 
 	return cmd
 }
 
 func (f *disableFlags) run() error {
-	if f.serverName == "" {
-		executablePath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("failed to determine executable path: %w", err)
-		}
-
-		f.serverName = manager.DeriveServerName(executablePath)
+	// Resolve the server name (flag → configured default → executable name).
+	serverName, err := manager.ResolveServerName(f.serverName, f.defaultServerName)
+	if err != nil {
+		return err
 	}
 
 	m, err := manager.NewCursorManager(f.configPath, f.workspace)
@@ -50,5 +46,5 @@ func (f *disableFlags) run() error {
 		return err
 	}
 
-	return m.DisableServer(f.serverName)
+	return m.DisableServer(serverName)
 }

--- a/internal/cfgmgr/cmd/cursor/enable.go
+++ b/internal/cfgmgr/cmd/cursor/enable.go
@@ -10,20 +10,22 @@ import (
 )
 
 type enableFlags struct {
-	commandName string
-	defaultEnv  map[string]string
-	configPath  string
-	logLevel    string
-	serverName  string
-	workspace   bool
-	env         map[string]string
+	commandName       string
+	defaultServerName string
+	defaultEnv        map[string]string
+	configPath        string
+	logLevel          string
+	serverName        string
+	workspace         bool
+	env               map[string]string
 }
 
 // enableCommand creates a Cobra command for adding an MCP server to Cursor.
 // commandName is the name of the ophis root command in the Cobra tree.
+// serverName is the default MCP server entry name; the --server-name flag overrides it.
 // defaultEnv is merged into the server env; user-provided --env values take precedence.
-func enableCommand(commandName string, defaultEnv map[string]string) *cobra.Command {
-	f := &enableFlags{commandName: commandName, defaultEnv: defaultEnv}
+func enableCommand(commandName, serverName string, defaultEnv map[string]string) *cobra.Command {
+	f := &enableFlags{commandName: commandName, defaultServerName: serverName, defaultEnv: defaultEnv}
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Add server to Cursor config",
@@ -37,7 +39,7 @@ func enableCommand(commandName string, defaultEnv map[string]string) *cobra.Comm
 	flags := cmd.Flags()
 	flags.StringVar(&f.logLevel, "log-level", "", "Log level (debug, info, warn, error)")
 	flags.StringVar(&f.configPath, "config-path", "", "Path to Cursor config file")
-	flags.StringVar(&f.serverName, "server-name", "", "Name for the MCP server (default: derived from executable name)")
+	flags.StringVar(&f.serverName, "server-name", "", manager.ServerNameUsage(serverName))
 	flags.BoolVar(&f.workspace, "workspace", false, "Add to workspace settings (.cursor/mcp.json) instead of user settings")
 	flags.StringToStringVarP(&f.env, "env", "e", nil, "Environment variables (e.g., --env KEY1=value1 --env KEY2=value2)")
 
@@ -81,8 +83,10 @@ func (f *enableFlags) run(cmd *cobra.Command) error {
 		server.Env = env
 	}
 
-	if f.serverName == "" {
-		f.serverName = manager.DeriveServerName(executablePath)
+	// Resolve the server name (flag → configured default → executable name).
+	f.serverName, err = manager.ResolveServerName(f.serverName, f.defaultServerName)
+	if err != nil {
+		return err
 	}
 
 	m, err := manager.NewCursorManager(f.configPath, f.workspace)

--- a/internal/cfgmgr/cmd/cursor/root.go
+++ b/internal/cfgmgr/cmd/cursor/root.go
@@ -7,8 +7,10 @@ import (
 // Command creates a new Cobra command for managing Cursor MCP servers.
 // commandName is the Use name of the ophis root command (e.g. "mcp" or "agent"),
 // threaded through to enableCommand so that GetCmdPath can locate it.
+// serverName is the default MCP server entry name for enable; the --server-name
+// flag overrides it, and an empty value falls back to the executable name.
 // defaultEnv is merged into the server env on enable; user --env values take precedence.
-func Command(commandName string, defaultEnv map[string]string) *cobra.Command {
+func Command(commandName, serverName string, defaultEnv map[string]string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cursor",
 		Short: "Manage Cursor MCP servers",
@@ -16,6 +18,6 @@ func Command(commandName string, defaultEnv map[string]string) *cobra.Command {
 	}
 
 	// Add subcommands
-	cmd.AddCommand(enableCommand(commandName, defaultEnv), disableCommand(), listCommand())
+	cmd.AddCommand(enableCommand(commandName, serverName, defaultEnv), disableCommand(serverName), listCommand())
 	return cmd
 }

--- a/internal/cfgmgr/cmd/vscode/disable.go
+++ b/internal/cfgmgr/cmd/vscode/disable.go
@@ -1,22 +1,21 @@
 package vscode
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/njayp/ophis/internal/cfgmgr/manager"
 	"github.com/spf13/cobra"
 )
 
 type disableFlags struct {
-	configPath string
-	serverName string
-	workspace  bool
+	defaultServerName string
+	configPath        string
+	serverName        string
+	workspace         bool
 }
 
 // disableCommand creates a Cobra command for removing an MCP server from VSCode.
-func disableCommand() *cobra.Command {
-	f := &disableFlags{}
+// serverName is the default MCP server entry name; the --server-name flag overrides it.
+func disableCommand(serverName string) *cobra.Command {
+	f := &disableFlags{defaultServerName: serverName}
 	cmd := &cobra.Command{
 		Use:   "disable",
 		Short: "Remove server from VSCode config",
@@ -29,20 +28,17 @@ func disableCommand() *cobra.Command {
 	// Add flags
 	flags := cmd.Flags()
 	flags.StringVar(&f.configPath, "config-path", "", "Path to VSCode config file")
-	flags.StringVar(&f.serverName, "server-name", "", "Name of the MCP server to remove (default: derived from executable name)")
+	flags.StringVar(&f.serverName, "server-name", "", manager.ServerNameRemoveUsage(serverName))
 	flags.BoolVar(&f.workspace, "workspace", false, "Remove from workspace settings (.vscode/mcp.json) instead of user settings")
 
 	return cmd
 }
 
 func (f *disableFlags) run() error {
-	if f.serverName == "" {
-		executablePath, err := os.Executable()
-		if err != nil {
-			return fmt.Errorf("failed to determine executable path: %w", err)
-		}
-
-		f.serverName = manager.DeriveServerName(executablePath)
+	// Resolve the server name (flag → configured default → executable name).
+	serverName, err := manager.ResolveServerName(f.serverName, f.defaultServerName)
+	if err != nil {
+		return err
 	}
 
 	m, err := manager.NewVSCodeManager(f.configPath, f.workspace)
@@ -50,5 +46,5 @@ func (f *disableFlags) run() error {
 		return err
 	}
 
-	return m.DisableServer(f.serverName)
+	return m.DisableServer(serverName)
 }

--- a/internal/cfgmgr/cmd/vscode/enable.go
+++ b/internal/cfgmgr/cmd/vscode/enable.go
@@ -10,20 +10,22 @@ import (
 )
 
 type enableFlags struct {
-	commandName string
-	defaultEnv  map[string]string
-	configPath  string
-	logLevel    string
-	serverName  string
-	workspace   bool
-	env         map[string]string
+	commandName       string
+	defaultServerName string
+	defaultEnv        map[string]string
+	configPath        string
+	logLevel          string
+	serverName        string
+	workspace         bool
+	env               map[string]string
 }
 
 // enableCommand creates a Cobra command for adding an MCP server to VSCode.
 // commandName is the Use name of the ophis root command (e.g. "mcp" or "agent").
+// serverName is the default MCP server entry name; the --server-name flag overrides it.
 // defaultEnv is merged into the server env; user-provided --env values take precedence.
-func enableCommand(commandName string, defaultEnv map[string]string) *cobra.Command {
-	f := &enableFlags{commandName: commandName, defaultEnv: defaultEnv}
+func enableCommand(commandName, serverName string, defaultEnv map[string]string) *cobra.Command {
+	f := &enableFlags{commandName: commandName, defaultServerName: serverName, defaultEnv: defaultEnv}
 	cmd := &cobra.Command{
 		Use:   "enable",
 		Short: "Add server to VSCode config",
@@ -37,7 +39,7 @@ func enableCommand(commandName string, defaultEnv map[string]string) *cobra.Comm
 	flags := cmd.Flags()
 	flags.StringVar(&f.logLevel, "log-level", "", "Log level (debug, info, warn, error)")
 	flags.StringVar(&f.configPath, "config-path", "", "Path to VSCode config file")
-	flags.StringVar(&f.serverName, "server-name", "", "Name for the MCP server (default: derived from executable name)")
+	flags.StringVar(&f.serverName, "server-name", "", manager.ServerNameUsage(serverName))
 	flags.BoolVar(&f.workspace, "workspace", false, "Add to workspace settings (.vscode/mcp.json) instead of user settings")
 	flags.StringToStringVarP(&f.env, "env", "e", nil, "Environment variables (e.g., --env KEY1=value1 --env KEY2=value2)")
 
@@ -81,8 +83,10 @@ func (f *enableFlags) run(cmd *cobra.Command) error {
 		server.Env = env
 	}
 
-	if f.serverName == "" {
-		f.serverName = manager.DeriveServerName(executablePath)
+	// Resolve the server name (flag → configured default → executable name).
+	f.serverName, err = manager.ResolveServerName(f.serverName, f.defaultServerName)
+	if err != nil {
+		return err
 	}
 
 	m, err := manager.NewVSCodeManager(f.configPath, f.workspace)

--- a/internal/cfgmgr/cmd/vscode/root.go
+++ b/internal/cfgmgr/cmd/vscode/root.go
@@ -7,8 +7,10 @@ import (
 // Command creates a new Cobra command for managing VSCode MCP servers.
 // commandName is the name of the ophis command in the Cobra tree (e.g. "mcp" or "agent"),
 // used by enable to build the correct command path for editor config files.
+// serverName is the default MCP server entry name for enable; the --server-name
+// flag overrides it, and an empty value falls back to the executable name.
 // defaultEnv is merged into the server env on enable; user --env values take precedence.
-func Command(commandName string, defaultEnv map[string]string) *cobra.Command {
+func Command(commandName, serverName string, defaultEnv map[string]string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vscode",
 		Short: "Manage VSCode MCP servers",
@@ -16,6 +18,6 @@ func Command(commandName string, defaultEnv map[string]string) *cobra.Command {
 	}
 
 	// Add subcommands
-	cmd.AddCommand(enableCommand(commandName, defaultEnv), disableCommand(), listCommand())
+	cmd.AddCommand(enableCommand(commandName, serverName, defaultEnv), disableCommand(serverName), listCommand())
 	return cmd
 }

--- a/internal/cfgmgr/manager/utils.go
+++ b/internal/cfgmgr/manager/utils.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -17,6 +18,49 @@ func DeriveServerName(executablePath string) string {
 		serverName = serverName[:len(serverName)-len(ext)]
 	}
 	return serverName
+}
+
+// ResolveServerName determines the MCP server entry name using the precedence:
+// the --server-name flag wins, then the configured default, then a name derived
+// from the current executable's file name. Keeping this in one place ensures
+// enable and disable resolve the name identically across all editors.
+func ResolveServerName(flag, defaultName string) (string, error) {
+	if flag != "" {
+		return flag, nil
+	}
+	if defaultName != "" {
+		return defaultName, nil
+	}
+	executablePath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine executable path: %w", err)
+	}
+	return DeriveServerName(executablePath), nil
+}
+
+// ServerNameUsage returns the help text for the `--server-name` flag on
+// `enable`, describing the default that applies when the flag is omitted.
+// defaultServerName is the name configured via Config.ServerName; when empty,
+// the name is derived from the executable's file name instead.
+func ServerNameUsage(defaultServerName string) string {
+	return serverNameUsage("Name for the MCP server", defaultServerName)
+}
+
+// ServerNameRemoveUsage returns the help text for the `--server-name` flag on
+// `disable`, describing the default that applies when the flag is omitted.
+// defaultServerName is the name configured via Config.ServerName; when empty,
+// the name is derived from the executable's file name instead.
+func ServerNameRemoveUsage(defaultServerName string) string {
+	return serverNameUsage("Name of the MCP server to remove", defaultServerName)
+}
+
+// serverNameUsage renders the shared default clause for the `--server-name`
+// flag onto the given prefix.
+func serverNameUsage(prefix, defaultServerName string) string {
+	if defaultServerName != "" {
+		return fmt.Sprintf("%s (default: %q)", prefix, defaultServerName)
+	}
+	return fmt.Sprintf("%s (default: derived from executable name)", prefix)
 }
 
 // GetCmdPath builds the command path to the ophis command.

--- a/internal/cfgmgr/manager/utils_test.go
+++ b/internal/cfgmgr/manager/utils_test.go
@@ -50,6 +50,28 @@ func TestDeriveServerName(t *testing.T) {
 	}
 }
 
+func TestResolveServerName(t *testing.T) {
+	t.Run("flag wins over default", func(t *testing.T) {
+		name, err := ResolveServerName("from-flag", "from-config")
+		require.NoError(t, err)
+		assert.Equal(t, "from-flag", name)
+	})
+
+	t.Run("configured default used when flag empty", func(t *testing.T) {
+		name, err := ResolveServerName("", "from-config")
+		require.NoError(t, err)
+		assert.Equal(t, "from-config", name)
+	})
+
+	t.Run("falls back to executable name", func(t *testing.T) {
+		// With neither flag nor default set, the name is derived from the
+		// running test binary; assert it resolves to a non-empty value.
+		name, err := ResolveServerName("", "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, name)
+	})
+}
+
 func TestGetCmdPath(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/root.go
+++ b/root.go
@@ -13,8 +13,10 @@ func Command(config *Config) *cobra.Command {
 	name := config.commandName()
 
 	var defaultEnv map[string]string
+	var serverName string
 	if config != nil {
 		defaultEnv = config.DefaultEnv
+		serverName = config.ServerName
 	}
 
 	cmd := &cobra.Command{
@@ -28,9 +30,9 @@ func Command(config *Config) *cobra.Command {
 		startCommand(config),
 		toolCommand(config),
 		streamCommand(config),
-		claude.Command(name, defaultEnv),
-		vscode.Command(name, defaultEnv),
-		cursor.Command(name, defaultEnv),
+		claude.Command(name, serverName, defaultEnv),
+		vscode.Command(name, serverName, defaultEnv),
+		cursor.Command(name, serverName, defaultEnv),
 	)
 	return cmd
 }

--- a/test/help_test.go
+++ b/test/help_test.go
@@ -1,0 +1,108 @@
+package test
+
+import (
+	"bytes"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/njayp/ophis"
+)
+
+// updateGolden regenerates the golden files instead of asserting against them.
+// Run: go test ./test -run 'TestUsage|TestHelp' -update
+var updateGolden = flag.Bool("update", false, "update help/usage golden files")
+
+// TestUsage asserts the `Usage()` output of every command in the ophis tree
+// against a golden file, so changes to flag help strings are caught in review.
+func TestUsage(t *testing.T) {
+	cmd := ophis.Command(nil)
+	walkCommandOutput(t, cmd.Name(), cmd, "usage", func(c *cobra.Command) error {
+		return c.Usage()
+	})
+}
+
+// TestHelp asserts the `Help()` output of every command in the ophis tree
+// against a golden file.
+func TestHelp(t *testing.T) {
+	cmd := ophis.Command(nil)
+	walkCommandOutput(t, cmd.Name(), cmd, "help", func(c *cobra.Command) error {
+		return c.Help()
+	})
+}
+
+// TestEnableServerNameUsageFromConfig checks that a configured Config.ServerName
+// is reflected in the `--server-name` flag help on every editor's `enable`
+// command. The golden tests above cover the empty-ServerName branch (nil config);
+// this covers the configured branch.
+func TestEnableServerNameUsageFromConfig(t *testing.T) {
+	cmd := ophis.Command(&ophis.Config{ServerName: "my-cli"})
+	for _, editor := range []string{"claude", "vscode", "cursor"} {
+		t.Run(editor, func(t *testing.T) {
+			enable := findCommand(t, cmd, editor, "enable")
+			flag := enable.Flags().Lookup("server-name")
+			require.NotNil(t, flag, "enable should have a --server-name flag")
+			assert.Equal(t, `Name for the MCP server (default: "my-cli")`, flag.Usage)
+		})
+	}
+}
+
+// findCommand walks from parent down the given subcommand path, failing the test
+// if any segment is missing.
+func findCommand(t *testing.T, parent *cobra.Command, path ...string) *cobra.Command {
+	t.Helper()
+	cmd := parent
+	for _, name := range path {
+		var next *cobra.Command
+		for _, sub := range cmd.Commands() {
+			if sub.Name() == name {
+				next = sub
+				break
+			}
+		}
+		require.NotNil(t, next, "command %q not found under %q", name, cmd.Name())
+		cmd = next
+	}
+	return cmd
+}
+
+// walkCommandOutput renders cmd (and each of its subcommands, recursively) with
+// render, comparing the captured output to testdata/<baseDir>/<path>.txt. prefix
+// is the command path used to name the golden file (e.g. "mcp/claude/enable").
+func walkCommandOutput(t *testing.T, prefix string, cmd *cobra.Command, baseDir string, render func(*cobra.Command) error) {
+	t.Helper()
+	t.Run(cmd.Name(), func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		cmd.SetOut(buf)
+		cmd.SetErr(buf)
+		require.NoError(t, render(cmd))
+
+		assertGolden(t, buf.String(), filepath.Join(baseDir, prefix+".txt"))
+
+		for _, sub := range cmd.Commands() {
+			walkCommandOutput(t, filepath.Join(prefix, sub.Name()), sub, baseDir, render)
+		}
+	})
+}
+
+// assertGolden compares got to the golden file at testdata/<name>, or rewrites
+// the golden file when -update is set.
+func assertGolden(t *testing.T, got, name string) {
+	t.Helper()
+	goldenPath := filepath.Join("testdata", name)
+
+	if *updateGolden {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, []byte(got), 0o644))
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err, "missing golden file %s (run: go test ./test -update)", goldenPath)
+	assert.Equal(t, string(want), got, "help output for %s changed (run: go test ./test -update to accept)", name)
+}

--- a/test/servername_test.go
+++ b/test/servername_test.go
@@ -1,0 +1,124 @@
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/njayp/ophis"
+	"github.com/njayp/ophis/internal/cfgmgr/manager"
+	"github.com/njayp/ophis/internal/cfgmgr/manager/claude"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createServerNameCommand creates a command tree with Config.ServerName set.
+// The enable command is invoked with --config-path so the test never touches
+// the real Claude Desktop config.
+func createServerNameCommand(serverName string) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "testcli",
+		Short: "Test CLI for ServerName",
+	}
+
+	status := &cobra.Command{
+		Use:   "status",
+		Short: "Show status",
+		Run:   func(_ *cobra.Command, _ []string) {},
+	}
+
+	root.AddCommand(status)
+	root.AddCommand(ophis.Command(&ophis.Config{
+		CommandName: "agent",
+		ServerName:  serverName,
+	}))
+
+	return root
+}
+
+// readClaudeConfigNames reads a Claude Desktop config file and returns the
+// names of all configured servers.
+func readClaudeConfigNames(t *testing.T, configPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err, "failed to read config file")
+
+	var cfg claude.Config
+	err = json.Unmarshal(data, &cfg)
+	require.NoError(t, err, "failed to parse config file")
+
+	names := make([]string, 0, len(cfg.Servers))
+	for name := range cfg.Servers {
+		names = append(names, name)
+	}
+	return names
+}
+
+func TestServerNameFromConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "claude_config.json")
+
+	cmd := createServerNameCommand("configured-name")
+	cmd.SetArgs([]string{"agent", "claude", "enable", "--config-path", configPath})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	names := readClaudeConfigNames(t, configPath)
+	assert.Equal(t, []string{"configured-name"}, names, "server should use the configured ServerName")
+}
+
+func TestServerNameFlagOverridesConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "claude_config.json")
+
+	cmd := createServerNameCommand("configured-name")
+	cmd.SetArgs([]string{
+		"agent", "claude", "enable",
+		"--config-path", configPath,
+		"--server-name", "flag-name",
+	})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	names := readClaudeConfigNames(t, configPath)
+	assert.Equal(t, []string{"flag-name"}, names, "--server-name should override the configured ServerName")
+}
+
+func TestServerNameEnableDisableRoundTrip(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "claude_config.json")
+
+	// enable writes an entry named after the configured ServerName.
+	enable := createServerNameCommand("configured-name")
+	enable.SetArgs([]string{"agent", "claude", "enable", "--config-path", configPath})
+	require.NoError(t, enable.Execute())
+
+	names := readClaudeConfigNames(t, configPath)
+	require.Equal(t, []string{"configured-name"}, names, "server should use the configured ServerName")
+
+	// disable (without --server-name) must resolve the same configured name
+	// and remove the entry, leaving nothing behind.
+	disable := createServerNameCommand("configured-name")
+	disable.SetArgs([]string{"agent", "claude", "disable", "--config-path", configPath})
+	require.NoError(t, disable.Execute())
+
+	names = readClaudeConfigNames(t, configPath)
+	assert.Empty(t, names, "disable should remove the entry created by enable")
+}
+
+func TestServerNameEmptyFallsBackToExecutable(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "claude_config.json")
+
+	// Empty ServerName and no --server-name flag: fall back to the
+	// executable-derived name.
+	cmd := createServerNameCommand("")
+	cmd.SetArgs([]string{"agent", "claude", "enable", "--config-path", configPath})
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	executablePath, err := os.Executable()
+	require.NoError(t, err)
+	expected := manager.DeriveServerName(executablePath)
+
+	names := readClaudeConfigNames(t, configPath)
+	assert.Equal(t, []string{expected}, names, "empty ServerName should fall back to the executable name")
+}

--- a/test/testdata/help/mcp.txt
+++ b/test/testdata/help/mcp.txt
@@ -1,0 +1,14 @@
+Manage MCP servers for AI assistants and code editors
+
+Usage:
+  mcp [command]
+
+Available Commands:
+  claude      Manage Claude Desktop MCP servers
+  cursor      Manage Cursor MCP servers
+  start       Start the MCP server
+  stream      Stream the MCP server over HTTP
+  tools       Export tools as JSON
+  vscode      Manage VSCode MCP servers
+
+Use "mcp [command] --help" for more information about a command.

--- a/test/testdata/help/mcp/claude.txt
+++ b/test/testdata/help/mcp/claude.txt
@@ -1,0 +1,11 @@
+Manage MCP server configuration for Claude Desktop
+
+Usage:
+  mcp claude [command]
+
+Available Commands:
+  disable     Remove server from Claude config
+  enable      Add server to Claude config
+  list        Show Claude MCP servers
+
+Use "mcp claude [command] --help" for more information about a command.

--- a/test/testdata/help/mcp/claude/disable.txt
+++ b/test/testdata/help/mcp/claude/disable.txt
@@ -1,0 +1,8 @@
+Remove this application from Claude Desktop MCP servers
+
+Usage:
+  mcp claude disable [flags]
+
+Flags:
+      --config-path string   Path to Claude config file
+      --server-name string   Name of the MCP server to remove (default: derived from executable name)

--- a/test/testdata/help/mcp/claude/enable.txt
+++ b/test/testdata/help/mcp/claude/enable.txt
@@ -1,0 +1,10 @@
+Add this application as an MCP server in Claude Desktop
+
+Usage:
+  mcp claude enable [flags]
+
+Flags:
+      --config-path string   Path to Claude config file
+  -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
+      --log-level string     Log level (debug, info, warn, error)
+      --server-name string   Name for the MCP server (default: derived from executable name)

--- a/test/testdata/help/mcp/claude/list.txt
+++ b/test/testdata/help/mcp/claude/list.txt
@@ -1,0 +1,7 @@
+Show all MCP servers configured in Claude Desktop
+
+Usage:
+  mcp claude list [flags]
+
+Flags:
+      --config-path string   Path to Claude config file

--- a/test/testdata/help/mcp/cursor.txt
+++ b/test/testdata/help/mcp/cursor.txt
@@ -1,0 +1,11 @@
+Manage MCP server configuration for Cursor
+
+Usage:
+  mcp cursor [command]
+
+Available Commands:
+  disable     Remove server from Cursor config
+  enable      Add server to Cursor config
+  list        Show Cursor MCP servers
+
+Use "mcp cursor [command] --help" for more information about a command.

--- a/test/testdata/help/mcp/cursor/disable.txt
+++ b/test/testdata/help/mcp/cursor/disable.txt
@@ -1,0 +1,9 @@
+Remove this application from Cursor MCP servers
+
+Usage:
+  mcp cursor disable [flags]
+
+Flags:
+      --config-path string   Path to Cursor config file
+      --server-name string   Name of the MCP server to remove (default: derived from executable name)
+      --workspace            Remove from workspace settings (.cursor/mcp.json) instead of user settings

--- a/test/testdata/help/mcp/cursor/enable.txt
+++ b/test/testdata/help/mcp/cursor/enable.txt
@@ -1,0 +1,11 @@
+Add this application as an MCP server in Cursor
+
+Usage:
+  mcp cursor enable [flags]
+
+Flags:
+      --config-path string   Path to Cursor config file
+  -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
+      --log-level string     Log level (debug, info, warn, error)
+      --server-name string   Name for the MCP server (default: derived from executable name)
+      --workspace            Add to workspace settings (.cursor/mcp.json) instead of user settings

--- a/test/testdata/help/mcp/cursor/list.txt
+++ b/test/testdata/help/mcp/cursor/list.txt
@@ -1,0 +1,8 @@
+Show all MCP servers configured in Cursor
+
+Usage:
+  mcp cursor list [flags]
+
+Flags:
+      --config-path string   Path to Cursor config file
+      --workspace            List from workspace settings (.cursor/mcp.json) instead of user settings

--- a/test/testdata/help/mcp/start.txt
+++ b/test/testdata/help/mcp/start.txt
@@ -1,0 +1,7 @@
+Start stdio server to expose CLI commands to AI assistants
+
+Usage:
+  mcp start [flags]
+
+Flags:
+      --log-level string   Log level (debug, info, warn, error)

--- a/test/testdata/help/mcp/stream.txt
+++ b/test/testdata/help/mcp/stream.txt
@@ -1,0 +1,9 @@
+Start HTTP server to expose CLI commands to AI assistants
+
+Usage:
+  mcp stream [flags]
+
+Flags:
+      --host string        host to listen on
+      --log-level string   Log level (debug, info, warn, error)
+      --port int           port number to listen on (default 8080)

--- a/test/testdata/help/mcp/tools.txt
+++ b/test/testdata/help/mcp/tools.txt
@@ -1,0 +1,7 @@
+Export available MCP tools to mcp-tools.json for inspection
+
+Usage:
+  mcp tools [flags]
+
+Flags:
+      --log-level string   Log level (debug, info, warn, error)

--- a/test/testdata/help/mcp/vscode.txt
+++ b/test/testdata/help/mcp/vscode.txt
@@ -1,0 +1,11 @@
+Manage MCP server configuration for Visual Studio Code
+
+Usage:
+  mcp vscode [command]
+
+Available Commands:
+  disable     Remove server from VSCode config
+  enable      Add server to VSCode config
+  list        Show VSCode MCP servers
+
+Use "mcp vscode [command] --help" for more information about a command.

--- a/test/testdata/help/mcp/vscode/disable.txt
+++ b/test/testdata/help/mcp/vscode/disable.txt
@@ -1,0 +1,9 @@
+Remove this application from VSCode MCP servers
+
+Usage:
+  mcp vscode disable [flags]
+
+Flags:
+      --config-path string   Path to VSCode config file
+      --server-name string   Name of the MCP server to remove (default: derived from executable name)
+      --workspace            Remove from workspace settings (.vscode/mcp.json) instead of user settings

--- a/test/testdata/help/mcp/vscode/enable.txt
+++ b/test/testdata/help/mcp/vscode/enable.txt
@@ -1,0 +1,11 @@
+Add this application as an MCP server in VSCode
+
+Usage:
+  mcp vscode enable [flags]
+
+Flags:
+      --config-path string   Path to VSCode config file
+  -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
+      --log-level string     Log level (debug, info, warn, error)
+      --server-name string   Name for the MCP server (default: derived from executable name)
+      --workspace            Add to workspace settings (.vscode/mcp.json) instead of user settings

--- a/test/testdata/help/mcp/vscode/list.txt
+++ b/test/testdata/help/mcp/vscode/list.txt
@@ -1,0 +1,8 @@
+Show all MCP servers configured in VSCode
+
+Usage:
+  mcp vscode list [flags]
+
+Flags:
+      --config-path string   Path to VSCode config file
+      --workspace            List from workspace settings (.vscode/mcp.json) instead of user settings

--- a/test/testdata/usage/mcp.txt
+++ b/test/testdata/usage/mcp.txt
@@ -1,0 +1,12 @@
+Usage:
+  mcp [command]
+
+Available Commands:
+  claude      Manage Claude Desktop MCP servers
+  cursor      Manage Cursor MCP servers
+  start       Start the MCP server
+  stream      Stream the MCP server over HTTP
+  tools       Export tools as JSON
+  vscode      Manage VSCode MCP servers
+
+Use "mcp [command] --help" for more information about a command.

--- a/test/testdata/usage/mcp/claude.txt
+++ b/test/testdata/usage/mcp/claude.txt
@@ -1,0 +1,9 @@
+Usage:
+  mcp claude [command]
+
+Available Commands:
+  disable     Remove server from Claude config
+  enable      Add server to Claude config
+  list        Show Claude MCP servers
+
+Use "mcp claude [command] --help" for more information about a command.

--- a/test/testdata/usage/mcp/claude/disable.txt
+++ b/test/testdata/usage/mcp/claude/disable.txt
@@ -1,0 +1,6 @@
+Usage:
+  mcp claude disable [flags]
+
+Flags:
+      --config-path string   Path to Claude config file
+      --server-name string   Name of the MCP server to remove (default: derived from executable name)

--- a/test/testdata/usage/mcp/claude/enable.txt
+++ b/test/testdata/usage/mcp/claude/enable.txt
@@ -1,0 +1,8 @@
+Usage:
+  mcp claude enable [flags]
+
+Flags:
+      --config-path string   Path to Claude config file
+  -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
+      --log-level string     Log level (debug, info, warn, error)
+      --server-name string   Name for the MCP server (default: derived from executable name)

--- a/test/testdata/usage/mcp/claude/list.txt
+++ b/test/testdata/usage/mcp/claude/list.txt
@@ -1,0 +1,5 @@
+Usage:
+  mcp claude list [flags]
+
+Flags:
+      --config-path string   Path to Claude config file

--- a/test/testdata/usage/mcp/cursor.txt
+++ b/test/testdata/usage/mcp/cursor.txt
@@ -1,0 +1,9 @@
+Usage:
+  mcp cursor [command]
+
+Available Commands:
+  disable     Remove server from Cursor config
+  enable      Add server to Cursor config
+  list        Show Cursor MCP servers
+
+Use "mcp cursor [command] --help" for more information about a command.

--- a/test/testdata/usage/mcp/cursor/disable.txt
+++ b/test/testdata/usage/mcp/cursor/disable.txt
@@ -1,0 +1,7 @@
+Usage:
+  mcp cursor disable [flags]
+
+Flags:
+      --config-path string   Path to Cursor config file
+      --server-name string   Name of the MCP server to remove (default: derived from executable name)
+      --workspace            Remove from workspace settings (.cursor/mcp.json) instead of user settings

--- a/test/testdata/usage/mcp/cursor/enable.txt
+++ b/test/testdata/usage/mcp/cursor/enable.txt
@@ -1,0 +1,9 @@
+Usage:
+  mcp cursor enable [flags]
+
+Flags:
+      --config-path string   Path to Cursor config file
+  -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
+      --log-level string     Log level (debug, info, warn, error)
+      --server-name string   Name for the MCP server (default: derived from executable name)
+      --workspace            Add to workspace settings (.cursor/mcp.json) instead of user settings

--- a/test/testdata/usage/mcp/cursor/list.txt
+++ b/test/testdata/usage/mcp/cursor/list.txt
@@ -1,0 +1,6 @@
+Usage:
+  mcp cursor list [flags]
+
+Flags:
+      --config-path string   Path to Cursor config file
+      --workspace            List from workspace settings (.cursor/mcp.json) instead of user settings

--- a/test/testdata/usage/mcp/start.txt
+++ b/test/testdata/usage/mcp/start.txt
@@ -1,0 +1,5 @@
+Usage:
+  mcp start [flags]
+
+Flags:
+      --log-level string   Log level (debug, info, warn, error)

--- a/test/testdata/usage/mcp/stream.txt
+++ b/test/testdata/usage/mcp/stream.txt
@@ -1,0 +1,7 @@
+Usage:
+  mcp stream [flags]
+
+Flags:
+      --host string        host to listen on
+      --log-level string   Log level (debug, info, warn, error)
+      --port int           port number to listen on (default 8080)

--- a/test/testdata/usage/mcp/tools.txt
+++ b/test/testdata/usage/mcp/tools.txt
@@ -1,0 +1,5 @@
+Usage:
+  mcp tools [flags]
+
+Flags:
+      --log-level string   Log level (debug, info, warn, error)

--- a/test/testdata/usage/mcp/vscode.txt
+++ b/test/testdata/usage/mcp/vscode.txt
@@ -1,0 +1,9 @@
+Usage:
+  mcp vscode [command]
+
+Available Commands:
+  disable     Remove server from VSCode config
+  enable      Add server to VSCode config
+  list        Show VSCode MCP servers
+
+Use "mcp vscode [command] --help" for more information about a command.

--- a/test/testdata/usage/mcp/vscode/disable.txt
+++ b/test/testdata/usage/mcp/vscode/disable.txt
@@ -1,0 +1,7 @@
+Usage:
+  mcp vscode disable [flags]
+
+Flags:
+      --config-path string   Path to VSCode config file
+      --server-name string   Name of the MCP server to remove (default: derived from executable name)
+      --workspace            Remove from workspace settings (.vscode/mcp.json) instead of user settings

--- a/test/testdata/usage/mcp/vscode/enable.txt
+++ b/test/testdata/usage/mcp/vscode/enable.txt
@@ -1,0 +1,9 @@
+Usage:
+  mcp vscode enable [flags]
+
+Flags:
+      --config-path string   Path to VSCode config file
+  -e, --env stringToString   Environment variables (e.g., --env KEY1=value1 --env KEY2=value2) (default [])
+      --log-level string     Log level (debug, info, warn, error)
+      --server-name string   Name for the MCP server (default: derived from executable name)
+      --workspace            Add to workspace settings (.vscode/mcp.json) instead of user settings

--- a/test/testdata/usage/mcp/vscode/list.txt
+++ b/test/testdata/usage/mcp/vscode/list.txt
@@ -1,0 +1,6 @@
+Usage:
+  mcp vscode list [flags]
+
+Flags:
+      --config-path string   Path to VSCode config file
+      --workspace            List from workspace settings (.vscode/mcp.json) instead of user settings


### PR DESCRIPTION
## What does this PR do?

Adds support to set the default server name for your app in config.

It means we'll be able to revert this PR https://github.com/CircleCI-Public/circleci-cli/pull/1631 :)

## Checklist

- [x] Tests added or updated
- [x] Docs added or updated